### PR TITLE
Correct manifest in order the addon to work with latest NVDA releases

### DIFF
--- a/speechHistory/manifest.ini
+++ b/speechHistory/manifest.ini
@@ -1,6 +1,6 @@
 ﻿name = speechHistory
 summary = Speech history review and copying
-description = This add-on allows you to review the 100 most recent strings spoken by NVDA, by default using Shift+F11 and Shift+F12.  Additionally, you can copy any spoken item to the clipboard by pressing F12.
+description = "This add-on allows you to review the 100 most recent strings spoken by NVDA, by default using Shift+F11 and Shift+F12.  Additionally, you can copy any spoken item to the clipboard by pressing F12."
 version = 2017.05.13
 url = https://github.com/jscholes/nvda-speech-history
-author = Tyler Spivey, James Scholes
+author = "Tyler Spivey, James Scholes"


### PR DESCRIPTION
This commit adds quotes surrounding description and author strings, which were not processed by latest NVDA beta causing the add-on installation to fail.

If any problem please comment.