### PR TITLE
Trim heading and trailing spaces when copying text.

### DIFF
--- a/speechHistory/globalPlugins/speechHistory.py
+++ b/speechHistory/globalPlugins/speechHistory.py
@@ -53,7 +53,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
         speech.speakSpelling = mySpeakSpelling
 
     def script_copyLast(self, gesture):
-        if api.copyToClip(history[history_pos]):
+        if api.copyToClip(history[history_pos].strip()):
             tones.beep(1500, 120)
 
     # Translators: Documentation string for copy currently selected speech history item script


### PR DESCRIPTION
Here is just a PR to trim leading and trailing spaces of the copied text (with F12).

Usecase:
Very useful when you are reading text in Windows console with review cursor and want to copy the last spoken line or a word... E.g. with git, copy a branch name after having run `git branch`.
