### PR TITLE
Make add-on compatible with add-ons that patch speech.speak.

### DIFF
--- a/speechHistory/globalPlugins/speechHistory.py
+++ b/speechHistory/globalPlugins/speechHistory.py
@@ -89,8 +89,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		super().terminate(*args, **kwargs)
 		if BUILD_YEAR >= 2021:
 			speech.speech.speak = self.oldSpeak
-		else:
-			speech.speak = self.oldSpeak
+		speech.speak = self.oldSpeak
 		gui.settingsDialogs.NVDASettingsDialog.categoryClasses.remove(SpeechHistorySettingsPanel)
 
 	def append_to_history(self, seq):

--- a/speechHistory/globalPlugins/speechHistory.py
+++ b/speechHistory/globalPlugins/speechHistory.py
@@ -45,6 +45,8 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		if BUILD_YEAR >= 2021:
 			self.oldSpeak = speech.speech.speak
 			speech.speech.speak = self.mySpeak
+			# Some add-ons still use the older speech.speak, so patch that as well.
+			speech.speak = self.mySpeak
 		else:
 			self.oldSpeak = speech.speak
 			speech.speak = self.mySpeak


### PR DESCRIPTION
closes #22 
In this PR, I made the patch method patch speech.speak even on newer NVDA versions as some add-ons, like Phonetic Punctuation, still used it, which caused speech history not being able to record anything to the history.