### PR TITLE
Fix compatibility (min NVDA version and doc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NVDA Speech History
 
-This is an updated version of the Clip Copy add-on for NVDA, initially created by Tyler Spivey in 2012.  The add-on is compatible with NVDA versions from 2019.3 to 2022.1.
+This is an updated version of the Clip Copy add-on for NVDA, initially created by Tyler Spivey in 2012.  The add-on is compatible with NVDA versions from 2020.4 to 2023.1.
 
 The original version of the add-on offered two keystrokes:
 

--- a/speechHistory/manifest.ini
+++ b/speechHistory/manifest.ini
@@ -5,4 +5,4 @@ version = "2023.1"
 url = "https://github.com/jscholes/nvda-speech-history"
 author = "Tyler Spivey, James Scholes"
 lastTestedNVDAVersion = "2023.1.0"
-minimumNVDAVersion = 2019.3.0
+minimumNVDAVersion = 2020.4.0


### PR DESCRIPTION
Hi James

Since I have no answer in #25, here is a PR fixing the compatibility for older versions. Hope it may be useful.

### Link to issue
Closes #25

### Issue
According to the manifest, the add-on is advertised to be compatible from 2019.3 to 2023.1. However, with 2019.3 there is the following error when the add-on is loaded:

```
ERROR - globalPluginHandler.listPlugins (08:44:44.258) - MainThread (24128):
Error importing global plugin speechHistory
Traceback (most recent call last):
  File "globalPluginHandler.pyc", line 23, in listPlugins
  File "importlib\__init__.pyc", line 127, in import_module
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "C:\Users\Cyrille\AppData\Roaming\nvda\addons\speechHistory\globalPlugins\speechHistory.py", line 13, in <module>
    from eventHandler import FocusLossCancellableSpeechCommand
ImportError: cannot import name 'FocusLossCancellableSpeechCommand' from 'eventHandler' (C:\Users\Cyrille\AppData\Local\Temp\nso72C2.tmp\app\library.zip\eventHandler.pyc)

```

Also the README of the GitHub repository still indicates 2022.1 as last compatible version.

### Solution
* Set 2020.4 as min NVDA version in the manifest; that is the version where `FocusLossCancellableSpeechCommand` has been introduced.
* Updated the README of the GitHub repo to reflect real compatibility range.
